### PR TITLE
Web App Fixes

### DIFF
--- a/web-app-example/Dockerfile
+++ b/web-app-example/Dockerfile
@@ -22,4 +22,4 @@ RUN adduser -u 5678 --disabled-password --gecos "" appuser && chown -R appuser /
 USER appuser
 
 # During debugging, this entry point will be overridden. For more information, please refer to https://aka.ms/vscode-docker-python-debug
-CMD ["gunicorn", "--bind", "0.0.0.0:5000", "server:app"]
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "server:server"]

--- a/web-app-example/requirements.txt
+++ b/web-app-example/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 Flask==3.0.0
+gunicorn==22.0.0


### PR DESCRIPTION
Re:
docker-compose up
Attaching to pythoncontainerdemo-1
Gracefully stopping... (press Ctrl+C again to force)
Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "gunicorn": executable file not found in $PATH: unknown


Then , when adding gunicorn to requirements.txt:

pythoncontainerdemo-1  | [2024-07-24 16:21:40 +0000] [1] [INFO] Starting gunicorn 22.0.0
pythoncontainerdemo-1  | [2024-07-24 16:21:40 +0000] [1] [INFO] Listening at: http://0.0.0.0:5000 (1)
pythoncontainerdemo-1  | [2024-07-24 16:21:40 +0000] [1] [INFO] Using worker: sync
pythoncontainerdemo-1  | [2024-07-24 16:21:40 +0000] [7] [INFO] Booting worker with pid: 7
pythoncontainerdemo-1  | Failed to find attribute 'app' in 'server'.
pythoncontainerdemo-1  | [2024-07-24 16:21:40 +0000] [7] [INFO] Worker exiting (pid: 7)
pythoncontainerdemo-1  | [2024-07-24 16:21:41 +0000] [1] [ERROR] Worker (pid:7) exited with code 4
pythoncontainerdemo-1  | [2024-07-24 16:21:41 +0000] [1] [ERROR] Shutting down: Master
pythoncontainerdemo-1  | [2024-07-24 16:21:41 +0000] [1] [ERROR] Reason: App failed to load.
pythoncontainerdemo-1 exited with code 4